### PR TITLE
Fix error in example - refer to intercept instead of slope

### DIFF
--- a/03-intro-linear-models.Rmd
+++ b/03-intro-linear-models.Rmd
@@ -541,7 +541,7 @@ Note that a higher family income corresponds to less aid because the coefficient
 We must be cautious in this interpretation: while there is a real association, we cannot interpret a causal connection between the variables because these data are observational. 
 That is, increasing a student's family income may not cause the student's aid to drop. (It would be reasonable to contact the college and ask if the relationship is causal, i.e. if Elmhurst College's aid decisions are partially based on students' family income.)
 
-The estimated intercept $b_0$ = `r m_ga_fi_slope` describes the average aid if a student's family had no income. 
+The estimated intercept $b_0$ = `r m_ga_fi_int` describes the average aid if a student's family had no income. 
 The meaning of the intercept is relevant to this application since the family income for some students at Elmhurst is \$0. 
 In other applications, the intercept may have little or no practical value if there are no observations where $x$ is near zero.
 :::


### PR DESCRIPTION
In the first example in Section 3.2.3, the example called the slope rather than the intercept when interpreting the intercept.