### PR TITLE
Copy license details from website

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,19 @@
+# License
+
 See https://www.openintro.org/license/ for license information.
+
+## License for resources
+
+Most of OpenIntro's resources, including the Statistics textbooks, are released under a Creative Commons BY-SA 3.0 license. Some files are downloaded in a zip directory (or Github repository) include a Read Me file and provide special guidelines to fulfill the attribution component of the license is fulfilled. Derivative works should also be clearly licensed under the Creative Commons BY-SA 3.0 license, e.g. by linking to the CC license, so that others may continue to benefit from sharing.
+
+Derivative work cannot be branded or titled in a way that suggests the derivative work is an OpenIntro product or is endorsed by OpenIntro. For example, printing books using the original title of an OpenIntro textbook (to remove ambiguity, this includes the translation equivalent), such as OpenIntro Statistics or Advanced High School Statistics as examples, is not permitted. OpenIntro is also a registered trademark. If you would like for a derivative work to branded as an OpenIntro resource or to use the same title (e.g. if the derivative is a translation), please [contact us](https://www.openintro.org/go?id=contact&referrer=/license/index.php).
+
+Creative Commons Attribution-ShareAlike License
+
+## Exceptions
+
+Some files are subject to an alternative license. Teacher-only resources and student projects are two such examples. If a file does not have a license on it, assume it is not openly licensed.
+
+Branding elements (e.g. trademark and logo), OpenIntro's website, book covers, etc are also copyrighted and are not licensed for general use.
+
+Some materials, such as lecture slides, may contain images that are used under an alternative license or under fair use.


### PR DESCRIPTION
I think it is convenient if the licensing details are in the repository itself. Copied the text from the website and markdown-ified.

Also corrected a typo on "includes".