### PR TITLE
Adding escapes for proper evaluation of math equation

### DIFF
--- a/model-mlr.qmd
+++ b/model-mlr.qmd
@@ -269,7 +269,7 @@ How much larger of an interest rate would we expect for a borrower who has verif
 :::
 
 [^08-model-mlr-3]: Relative to the `Not Verified` category, the `Verified` category has an interest rate of 3.25% higher, while the `Source Verified` category is only 1.42% higher.
-    Thus, `Verified` borrowers will tend to get an interest rate about $3.25% - 1.42% = 1.83%$ higher than `Source Verified` borrowers.
+    Thus, `Verified` borrowers will tend to get an interest rate about $3.25\% - 1.42\% = 1.83\%$ higher than `Source Verified` borrowers.
 
 ## Many predictors in a model
 


### PR DESCRIPTION
text was just showing 3.25 instead of evaluating everything between the dollar signs