### PR TITLE
Typo in Chapter 6, section 6.1.5: 

### DIFF
--- a/explore-applications.qmd
+++ b/explore-applications.qmd
@@ -289,7 +289,7 @@ brexit |>
 
 The Brexit survey results were additionally broken down by region in Great Britain.
 The stacked bar plot allows for comparison of Brexit opinion across the five regions.
-In @fig-brexit-region-1 the bars are vertical and in @fig-brexit-region-1 they are horizontal. 
+In @fig-brexit-region-1 the bars are vertical and in @fig-brexit-region-2 they are horizontal. 
 While the quantitative information in the two graphics is identical, flipping the graph and creating horizontal bars provides more space for the **axis labels**.
 The easier the categories are to read, the more the reader will learn from the visualization.
 Remember, the goal is to convey as much information as possible in a succinct and clear manner.


### PR DESCRIPTION
This PR fixed the figure call to the correct figure. The body of text originally referred to the same figure. Now, [Figure 6.5 (b)] is being stated correctly to align with the books reference to the figure