### PR TITLE
# Fix typo in chapter 5, section 5.8

### DIFF
--- a/explore-numerical.qmd
+++ b/explore-numerical.qmd
@@ -1231,7 +1231,7 @@ terms_chp_05 <- c(terms_chp_05, "intensity map")
 ```
 
 ::: {.workedexample data-latex=""}
-What interesting features are evident in the poverty and unemployment rate intensity maps in @fig-county-intensity-maps-3 and @fig-county-intensity-maps-4?
+What interesting features are evident in the poverty and unemployment rate intensity maps in @fig-county-intensity-maps-1 and @fig-county-intensity-maps-2?
 
 ------------------------------------------------------------------------
 
@@ -1245,7 +1245,7 @@ One observation that stands out when comparing the two maps: the poverty rate is
 :::
 
 ::: {.guidedpractice data-latex=""}
-What interesting features are evident in the median household income intensity map in @fig-county-intensity-maps-2?[^05-explore-numerical-14]
+What interesting features are evident in the median household income intensity map in @fig-county-intensity-maps-4?[^05-explore-numerical-14]
 :::
 
 [^05-explore-numerical-14]: Answers will vary.


### PR DESCRIPTION
this PR addresses issue #493 

1. Section 5.8 example questions now references correct figures [Figure 5.12 (a)] and [Figure 5.12 (b)] poverty and unemployment rate, respectively, in concordance with example text.

2. Section 5.8 guided practice question now references correct figure Figure 5.12 (d) In concordance with guided practice text.