### PR TITLE
Correct typo in variable name (app_type -> application_type)

### DIFF
--- a/explore-categorical.qmd
+++ b/explore-categorical.qmd
@@ -313,7 +313,7 @@ loans |>
 A contingency table of the **column proportions**\index{column proportions} is computed in a similar way, where each is computed as the count divided by the corresponding column total.
 @tbl-loan-home-app-type-column-proportions shows such a table, and here the value 0.906 indicates that 90.6% of renters applied as individuals for the loan.
 This rate is higher compared to loans from people with mortgages (80.2%) or who own their home (86.5%).
-Because these rates vary between the three levels of `homeownership` (`rent`, `mortgage`, `own`), this provides evidence that `app_type` and `homeownership` variables may be associated.
+Because these rates vary between the three levels of `homeownership` (`rent`, `mortgage`, `own`), this provides evidence that `application_type` and `homeownership` variables may be associated.
 
 ```{r}
 #| label: tbl-loan-home-app-type-column-proportions


### PR DESCRIPTION
I fixed a small typo in the variable name (it should say application_type, not app_type)