### PR TITLE
Update _01-ex-data-hello.qmd

### DIFF
--- a/exercises/_01-ex-data-hello.qmd
+++ b/exercises/_01-ex-data-hello.qmd
@@ -88,8 +88,8 @@
 \vfill
 
 3.  **Air pollution and birth outcomes, study components.** Researchers collected data to examine the relationship between air pollutants and preterm births in Southern California.
-    During the study air pollution levels were measured by air quality monitoring stations.
-    Specifically, levels of carbon monoxide were recorded in parts per million, nitrogen dioxide and ozone in parts per hundred million, and coarse particulate matter (PM$_{10}$) in $\mu g/m^3$.
+    During the study, air pollution levels were measured by air quality monitoring stations.
+    Specifically, levels of carbon monoxide were recorded in parts per million, nitrogen dioxide and ozone in parts per hundred million, and inhalable particulate matter (PM$_{10}$) in $\mu g/m^3$.
     Length of gestation data were collected on 143,196 births between the years 1989 and 1993, and air pollution exposure during gestation was calculated for each birth.
     The analysis suggested that increased ambient PM$_{10}$ and, to a lesser degree, CO concentrations may be associated with the occurrence of preterm births.
     [@Ritz+Yu+Chapa+Fruin:2000]


### PR DESCRIPTION
Corrected the alternative name of PM10 for accuracy in environmental science - "coarse particulate matter" means the fraction of PM10 minus PM2.5, i.e., particulate matter with an aerodynamic diameter between 2.5 and 10 micrometres.